### PR TITLE
feat: Issue #1 データ読み込みダッシュボードの実装

### DIFF
--- a/.cursor/rules.mdc
+++ b/.cursor/rules.mdc
@@ -1,0 +1,22 @@
+---
+alwaysApply: true
+---
+
+# Cursor ルール
+
+## ワークフロー基本方針
+- 実装前に必ずGitHub Issueを作成し、課題概要・背景・受け入れ条件を記載する。
+- 作業開始時にIssueへ「着手します」等のコメントを残す。
+- `feature/<issue-number>-<short-slug>` 形式でIssue番号を含むブランチを作成する。
+- コミットメッセージにはIssue番号を含め、PR本文には `close #<issue-number>` を記載してIssueと紐付ける。
+- 動作確認・テスト結果をPRにまとめ、レビュー対応後にマージする。
+
+## Atomicデザイン規約
+- `src/components` 配下は `atoms` / `molecules` / `organisms` / `templates` / `pages` に分類し、責務と再利用性に応じて配置する。
+- コンポーネント名はPascalCaseとし、関連するStorybookファイルやテストファイルは同じ階層に置く。
+- Atomsはデザインシステムの最小単位、MoleculesはAtomsの組み合わせ、OrganismsはUIセクション、Templatesはページレイアウト、Pagesは具体的なページ実装とする。
+
+## Composable・ストア利用方針
+- データ取得や集計などのビジネスロジックは `src/composables` に切り出し、UI層から直接データソースへアクセスしない。
+- Piniaストアはグローバル状態・設定値の共有に限定し、Composableで副作用を管理してテストしやすさを確保する。
+

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,6 @@
-import { defineConfig } from 'postcss'
 import tailwindcss from 'tailwindcss'
 import autoprefixer from 'autoprefixer'
 
-export default defineConfig({
+export default {
   plugins: [tailwindcss(), autoprefixer()],
-})
+}

--- a/public/data/spotifyHistoryData
+++ b/public/data/spotifyHistoryData
@@ -1,1 +1,1 @@
-spotifyHistoryData
+../../spotifyHistoryData

--- a/src/composables/useSpotifyData.ts
+++ b/src/composables/useSpotifyData.ts
@@ -22,20 +22,50 @@ const toFileName = (filePath: string): string => {
 }
 
 const normalizeItems = (items: SpotifyHistoryItem[]): SpotifyHistoryItem[] =>
-  items.filter((item) =>
-    Boolean(
-      item &&
-        typeof item === 'object' &&
-        typeof item.ts === 'string' &&
-        !Number.isNaN(Date.parse(item.ts)) &&
-        item.ms_played > 0
+  items
+    .filter((item) =>
+      Boolean(
+        item &&
+          typeof item === 'object' &&
+          typeof item.ts === 'string' &&
+          !Number.isNaN(Date.parse(item.ts)) &&
+          typeof item.ms_played === 'number' &&
+          item.ms_played > 0
+      )
     )
-  )
+    .map((item) => ({
+      ...item,
+      ms_played: Math.floor(item.ms_played),
+    }))
+
+const dedupeItems = (items: SpotifyHistoryItem[]): SpotifyHistoryItem[] => {
+  const seen = new Set<string>()
+  const deduped: SpotifyHistoryItem[] = []
+
+  items.forEach((item) => {
+    const key = [
+      item.ts,
+      item.master_metadata_track_name ?? '',
+      item.master_metadata_album_artist_name ?? '',
+      item.ms_played,
+    ].join('::')
+
+    if (!seen.has(key)) {
+      seen.add(key)
+      deduped.push(item)
+    }
+  })
+
+  return deduped
+}
 
 const sortByTimestamp = (items: SpotifyHistoryItem[]): SpotifyHistoryItem[] =>
-  [...items].sort(
-    (a, b) => new Date(a.ts).getTime() - new Date(b.ts).getTime()
-  )
+  [...items].sort((a, b) => Date.parse(a.ts) - Date.parse(b.ts))
+
+interface LoadedHistoryData {
+  sourcePath: string
+  data: SpotifyHistoryData
+}
 
 export function useSpotifyData() {
   const dataStore = useDataStore()
@@ -45,42 +75,82 @@ export function useSpotifyData() {
     dataStore.error = null
 
     try {
-      const loadedModules = await Promise.all(
-        Object.entries(historyFileImporters).map(async ([filePath, importer]) => {
-          const module = await importer()
-          const items = Array.isArray(module?.default)
-            ? module.default
-            : []
+      const importerEntries = Object.entries(historyFileImporters)
 
-          const normalized = normalizeItems(items)
+      if (importerEntries.length === 0) {
+        throw new Error('Spotify履歴データの読み込み対象が見つかりません。')
+      }
 
-          const historyData: SpotifyHistoryData = {
-            items: normalized,
-            source: toFileName(filePath),
-            loadedAt: new Date(),
+      const results = await Promise.all(
+        importerEntries.map(async ([filePath, importer]) => {
+          try {
+            const module = await importer()
+            const items = Array.isArray(module?.default) ? module.default : []
+
+            const normalized = normalizeItems(items)
+
+            const historyData: SpotifyHistoryData = {
+              items: normalized,
+              source: toFileName(filePath),
+              loadedAt: new Date(),
+            }
+
+            return {
+              status: 'fulfilled' as const,
+              sourcePath: filePath,
+              data: historyData,
+            }
+          } catch (error) {
+            return {
+              status: 'rejected' as const,
+              sourcePath: filePath,
+              reason: error,
+            }
           }
-
-          return historyData
         })
       )
 
-      if (loadedModules.length === 0) {
-        throw new Error('Spotify履歴データが見つかりません。')
+      const fulfilled = results.filter(
+        (result): result is LoadedHistoryData & { status: 'fulfilled' } =>
+          result.status === 'fulfilled'
+      )
+      const rejected = results.filter(
+        (result): result is { status: 'rejected'; sourcePath: string; reason: unknown } =>
+          result.status === 'rejected'
+      )
+
+      if (!fulfilled.length) {
+        const firstReason = rejected[0]?.reason
+        if (firstReason instanceof Error) {
+          throw firstReason
+        }
+        throw new Error('Spotify履歴データの読み込みに失敗しました。')
       }
-      
 
       const mergedItems = sortByTimestamp(
-        loadedModules.flatMap((module) => module.items)
+        dedupeItems(fulfilled.flatMap((entry) => entry.data.items))
       )
 
       dataStore.rawData = mergedItems
-      dataStore.processedData = null
-      dataStore.dataSources = loadedModules
-      dataStore.error = null
+      dataStore.dataSources = fulfilled.map((entry) => entry.data)
+
+      if (rejected.length) {
+        const messages = rejected.map(({ sourcePath, reason }) => {
+          const fileName = toFileName(sourcePath)
+          if (reason instanceof Error) {
+            return `${fileName}: ${reason.message}`
+          }
+          return `${fileName}: 読み込み時に不明なエラーが発生しました。`
+        })
+        dataStore.error = `一部の履歴データの読み込みに失敗しました。\n${messages.join('\n')}`
+      } else {
+        dataStore.error = null
+      }
 
       return {
         items: mergedItems,
-        sources: loadedModules,
+        sources: fulfilled.map((entry) => entry.data),
+        failedSources: rejected.map((entry) => toFileName(entry.sourcePath)),
       }
     } catch (error) {
       const message =
@@ -89,7 +159,6 @@ export function useSpotifyData() {
           : 'Spotify履歴データの読み込みに失敗しました。'
 
       dataStore.rawData = []
-      dataStore.processedData = null
       dataStore.dataSources = []
       dataStore.error = message
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -5,7 +5,7 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/',
     name: 'home',
-    component: () => import('./views/DashboardView.vue'),
+    component: () => import('../views/DashboardView.vue'),
   },
 ]
 

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,23 +1,225 @@
 <template>
-  <div class="dashboard-view">
-    <div class="container mx-auto px-4 py-8">
-      <h1 class="text-4xl font-bold mb-8 text-spotify-text-primary">
-        Spotify履歴ダッシュボード
-      </h1>
-      <p class="text-spotify-text-secondary">
-        ダッシュボードの実装は今後進めます。
-      </p>
+  <div class="dashboard-view min-h-screen bg-spotify-dark text-spotify-text-primary">
+    <div class="mx-auto w-full max-w-6xl px-6 py-10">
+      <header class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-[0.2em] text-spotify-text-muted">
+            Phase 1 · Data Loading
+          </p>
+          <h1 class="mt-2 text-3xl font-semibold text-white md:text-4xl">
+            Spotify履歴ダッシュボード
+          </h1>
+          <p class="mt-3 max-w-2xl text-sm text-spotify-text-secondary">
+            Spotifyの履歴JSONファイルをローカルから読み込み、分析ダッシュボードに必要なデータの土台を準備します。
+          </p>
+          <p v-if="formattedLatestLoadedAt" class="mt-2 text-xs text-spotify-text-muted">
+            最終更新: {{ formattedLatestLoadedAt }}
+          </p>
+        </div>
+        <button
+          type="button"
+          class="inline-flex items-center gap-2 self-start rounded-full bg-spotify-green px-5 py-2 text-sm font-semibold text-black transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-spotify-text-muted disabled:text-spotify-dark"
+          :disabled="isLoading"
+          @click="reload"
+        >
+          <span
+            v-if="isLoading"
+            class="h-4 w-4 animate-spin rounded-full border-2 border-black/70 border-t-transparent"
+            aria-hidden="true"
+          />
+          {{ isLoading ? '読み込み中…' : 'データを再読み込み' }}
+        </button>
+      </header>
+
+      <section class="mt-10 space-y-8">
+        <div
+          v-if="isLoading && !hasData"
+          class="flex h-40 items-center justify-center rounded-xl border border-spotify-border bg-spotify-dark-secondary"
+        >
+          <div class="flex items-center gap-3 text-spotify-text-secondary">
+            <span class="h-6 w-6 animate-spin rounded-full border-2 border-spotify-green border-t-transparent" />
+            <span>{{ loadingLabel }}</span>
+          </div>
+        </div>
+
+        <div
+          v-else-if="error"
+          class="space-y-4 rounded-xl border border-red-500/60 bg-red-500/10 p-6 text-sm text-red-200"
+        >
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <p class="font-semibold text-red-100">データ読み込みで問題が発生しました</p>
+            <button
+              type="button"
+              class="rounded-md border border-red-500/50 px-3 py-1 text-xs font-semibold text-red-100 transition hover:border-red-400 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+              :disabled="isLoading"
+              @click="reload"
+            >
+              再試行
+            </button>
+          </div>
+          <p class="whitespace-pre-line leading-relaxed text-red-100/80">
+            {{ error }}
+          </p>
+        </div>
+
+        <template v-if="hasData">
+          <div class="grid gap-6 md:grid-cols-3">
+            <div class="rounded-xl border border-spotify-border bg-spotify-dark-secondary p-6 shadow-lg shadow-black/30">
+              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-spotify-text-muted">総再生回数</p>
+              <p class="mt-3 text-4xl font-semibold text-white">
+                {{ totalPlays.toLocaleString() }}
+                <span class="ml-1 text-base font-normal text-spotify-text-secondary">回</span>
+              </p>
+            </div>
+
+            <div class="rounded-xl border border-spotify-border bg-spotify-dark-secondary p-6 shadow-lg shadow-black/30">
+              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-spotify-text-muted">総再生時間</p>
+              <p class="mt-3 text-3xl font-semibold text-white">{{ formattedTotalPlayTime }}</p>
+            </div>
+
+            <div class="rounded-xl border border-spotify-border bg-spotify-dark-secondary p-6 shadow-lg shadow-black/30">
+              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-spotify-text-muted">ユニークアーティスト</p>
+              <p class="mt-3 text-4xl font-semibold text-white">
+                {{ uniqueArtistCount.toLocaleString() }}
+                <span class="ml-1 text-base font-normal text-spotify-text-secondary">組</span>
+              </p>
+            </div>
+          </div>
+
+          <div class="rounded-xl border border-spotify-border bg-spotify-dark-secondary p-6 shadow-lg shadow-black/30">
+            <div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 class="text-lg font-semibold text-white">読み込み済みデータソース</h2>
+                <p class="text-sm text-spotify-text-secondary">全{{ dataSourceSummaries.length }}ファイル</p>
+              </div>
+            </div>
+            <ul class="mt-6 space-y-4 text-sm">
+              <li
+                v-for="summary in dataSourceSummaries"
+                :key="summary.source"
+                class="flex flex-wrap items-start justify-between gap-4 rounded-lg border border-spotify-border/60 bg-spotify-dark p-4 transition hover:border-spotify-green/60"
+              >
+                <div>
+                  <p class="font-medium text-white">{{ summary.source }}</p>
+                  <p class="mt-1 text-xs text-spotify-text-muted">
+                    読み込み日時: {{ formatFileLoadedAt(summary.loadedAt) }}
+                  </p>
+                </div>
+                <span class="text-sm font-semibold text-spotify-text-secondary">
+                  {{ summary.itemCount.toLocaleString() }} 件
+                </span>
+              </li>
+            </ul>
+          </div>
+        </template>
+      </section>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// DashboardView.vue
+import { computed, onMounted } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useSpotifyData } from '@/composables/useSpotifyData'
+import { useDataStore } from '@/stores/dataStore'
+
+const dataStore = useDataStore()
+const { rawData, dataSources, isLoading, error } = storeToRefs(dataStore)
+const { loadHistoryData } = useSpotifyData()
+
+const formatDuration = (ms: number): string => {
+  if (!ms || ms <= 0) {
+    return '0分'
+  }
+  const totalSeconds = Math.floor(ms / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  if (hours === 0) {
+    return `${minutes}分`
+  }
+  return `${hours}時間${minutes.toString().padStart(2, '0')}分`
+}
+
+const totalPlays = computed(() => rawData.value.length)
+const totalPlayTimeMs = computed(() =>
+  rawData.value.reduce((acc, item) => acc + (item?.ms_played ?? 0), 0)
+)
+const formattedTotalPlayTime = computed(() => formatDuration(totalPlayTimeMs.value))
+
+const uniqueArtistCount = computed(() => {
+  const set = new Set<string>()
+  rawData.value.forEach((item) => {
+    const artist =
+      item.master_metadata_album_artist_name ??
+      item.episode_show_name ??
+      item.audiobook_title ??
+      'Unknown Artist'
+    set.add(artist)
+  })
+  return set.size
+})
+
+const dataSourceSummaries = computed(() =>
+  dataSources.value.map((source) => ({
+    source: source.source,
+    itemCount: source.items.length,
+    loadedAt: source.loadedAt,
+  }))
+)
+
+const latestLoadedAt = computed(() => {
+  if (!dataSources.value.length) {
+    return null
+  }
+  return dataSources.value.reduce<Date | null>((latest, source) => {
+    if (!latest) {
+      return source.loadedAt
+    }
+    return latest.getTime() > source.loadedAt.getTime() ? latest : source.loadedAt
+  }, null)
+})
+
+const formattedLatestLoadedAt = computed(() => {
+  if (!latestLoadedAt.value) {
+    return null
+  }
+  return new Intl.DateTimeFormat('ja-JP', {
+    dateStyle: 'medium',
+    timeStyle: 'medium',
+  }).format(latestLoadedAt.value)
+})
+
+const hasData = computed(() => totalPlays.value > 0)
+const loadingLabel = computed(() =>
+  totalPlays.value ? 'データを再読み込み中…' : 'Spotify履歴データを読み込み中…'
+)
+
+const formatFileLoadedAt = (value: Date): string =>
+  new Intl.DateTimeFormat('ja-JP', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(value)
+
+const reload = async () => {
+  if (isLoading.value) {
+    return
+  }
+  try {
+    await loadHistoryData()
+  } catch (err) {
+    console.error('failed to load spotify history data', err)
+  }
+}
+
+onMounted(() => {
+  if (!rawData.value.length) {
+    void reload()
+  }
+})
 </script>
 
 <style scoped>
 .dashboard-view {
-  min-height: 100vh;
-  background-color: var(--bg-primary);
+  background: linear-gradient(180deg, rgba(18, 18, 18, 0.95), rgba(12, 12, 12, 0.98));
 }
 </style>


### PR DESCRIPTION
## 概要
- Spotify履歴JSONの読み込みパイプラインを正規化・重複排除・エラーハンドリング付きで強化
- ダッシュボードに読み込み状況・集計サマリー・データソース一覧表示と再読み込み操作を実装
- PostCSS設定の互換性調整とシンボリックリンクの修正によりビルドエラーを解消

close #1

## テスト
- npm run dev -- --host

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a data-loading dashboard and strengthens Spotify history ingestion with normalization, deduplication, and error handling.
> 
> - **Dashboard UI (`src/views/DashboardView.vue`)**
>   - Implements data-loading phase with reload button, loading/error states, and status labels.
>   - Displays summary metrics (total plays, total play time, unique artists) and a list of loaded data sources with timestamps and counts.
>   - Applies dark themed layout and gradient background.
> - **Data Layer (`src/composables/useSpotifyData.ts`)**
>   - Normalizes items: validates fields, enforces numeric `ms_played`, floors values, filters invalid/zero plays.
>   - Deduplicates records by composite key and sorts by timestamp via `Date.parse`.
>   - Loads multiple history files from `../../spotifyHistoryData/*.json` and `../../public/data/spotifyHistoryData/*.json` in parallel.
>   - Aggregates fulfilled results, captures per-file failures, and surfaces consolidated errors to the store; updates `rawData` and `dataSources`.
> - **Routing (`src/router/index.ts`)**
>   - Fixes route component import path to `../views/DashboardView.vue`.
> - **Build/Config**
>   - Simplifies PostCSS export to plain object in `postcss.config.js`.
>   - Updates `public/data/spotifyHistoryData` path to `../../spotifyHistoryData`.
> - **Docs**
>   - Adds `.cursor/rules.mdc` with workflow and architecture guidelines.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1afd5170f700d1459ef664e7f6fa679b181a3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->