### PR TITLE
feat: add stats overview dashboard (#3)

### DIFF
--- a/src/components/dashboard/StatsOverview.vue
+++ b/src/components/dashboard/StatsOverview.vue
@@ -1,0 +1,113 @@
+<template>
+  <section
+    class="rounded-2xl border border-spotify-border/70 bg-spotify-dark-secondary/80 p-6 shadow-lg shadow-black/40 backdrop-blur-sm"
+  >
+    <header class="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+      <div>
+        <p class="text-xs font-semibold uppercase tracking-[0.3em] text-spotify-text-muted">
+          Phase 1 · Stats Overview
+        </p>
+        <h2 class="mt-2 text-2xl font-semibold text-white md:text-3xl">再生スタッツ</h2>
+        <p class="mt-2 text-sm text-spotify-text-secondary">
+          Spotify履歴データから算出した集計情報です。
+        </p>
+      </div>
+
+      <div class="flex items-center gap-3 text-xs text-spotify-text-muted">
+        <span class="rounded-full border border-spotify-border/60 px-3 py-1">
+          データ期間
+        </span>
+        <span class="text-sm font-medium text-spotify-text-secondary">{{ dateRangeLabel }}</span>
+      </div>
+    </header>
+
+    <dl class="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div
+        v-for="metric in metrics"
+        :key="metric.label"
+        class="group relative overflow-hidden rounded-xl border border-spotify-border/60 bg-spotify-dark p-5 transition hover:border-spotify-green/70"
+      >
+        <dt class="text-xs font-semibold uppercase tracking-[0.25em] text-spotify-text-muted">
+          {{ metric.label }}
+        </dt>
+        <dd class="mt-3 text-3xl font-semibold text-white">
+          <span>{{ metric.value }}</span>
+          <span v-if="metric.suffix" class="ml-1 text-base font-medium text-spotify-text-secondary">
+            {{ metric.suffix }}
+          </span>
+        </dd>
+        <p class="mt-2 text-xs text-spotify-text-muted">{{ metric.caption }}</p>
+
+        <span class="pointer-events-none absolute -bottom-6 right-4 h-20 w-20 rounded-full bg-spotify-green/10 blur-2xl transition group-hover:bg-spotify-green/20" />
+      </div>
+    </dl>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useDataStore } from '@/stores/dataStore'
+import {
+  formatDateRange,
+  formatHoursAndMinutes,
+  formatMinutesAndSeconds,
+} from '@/utils/formatters'
+
+const dataStore = useDataStore()
+const { processedData } = storeToRefs(dataStore)
+
+const totalPlays = computed(() => processedData.value?.totalPlays ?? 0)
+const totalTimeMs = computed(() => processedData.value?.totalTimeMs ?? 0)
+
+const hasData = computed(() => totalPlays.value > 0)
+
+const averageTimeMs = computed(() => {
+  if (!hasData.value) {
+    return 0
+  }
+  return Math.round(totalTimeMs.value / totalPlays.value)
+})
+
+const totalPlayTimeLabel = computed(() => formatHoursAndMinutes(totalTimeMs.value))
+const averagePlayTimeLabel = computed(() =>
+  hasData.value ? formatMinutesAndSeconds(averageTimeMs.value) : 'データなし'
+)
+
+const dateRangeLabel = computed(() => {
+  const range = processedData.value?.dateRange
+  if (!range) {
+    return 'データなし'
+  }
+  return formatDateRange(range.start, range.end)
+})
+
+const metrics = computed(() => [
+  {
+    label: '総再生時間',
+    value: totalPlayTimeLabel.value,
+    suffix: null,
+    caption: '全期間の再生時間（時間・分）',
+  },
+  {
+    label: '総再生回数',
+    value: hasData.value ? totalPlays.value.toLocaleString() : '0',
+    suffix: '回',
+    caption: '履歴に含まれる再生数',
+  },
+  {
+    label: '平均再生時間',
+    value: averagePlayTimeLabel.value,
+    suffix: null,
+    caption: '1再生あたりの平均時間',
+  },
+  {
+    label: 'データ期間',
+    value: dateRangeLabel.value,
+    suffix: null,
+    caption: '最初の再生日〜最新の再生日',
+  },
+])
+</script>
+
+

--- a/src/composables/useSpotifyData.ts
+++ b/src/composables/useSpotifyData.ts
@@ -92,6 +92,7 @@ export function useSpotifyData() {
             const historyData: SpotifyHistoryData = {
               items: normalized,
               source: toFileName(filePath),
+              sourcePath: filePath,
               loadedAt: new Date(),
             }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,7 @@ export interface SpotifyHistoryItem {
 export interface SpotifyHistoryData {
   items: SpotifyHistoryItem[];
   source: string; // ファイル名またはAPIソース
+  sourcePath: string;
   loadedAt: Date;
 }
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,0 +1,49 @@
+import { format, isValid } from 'date-fns'
+
+export const formatHoursAndMinutes = (ms: number): string => {
+  if (!ms || ms <= 0) {
+    return '0分'
+  }
+
+  const totalMinutes = Math.floor(ms / 60000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+
+  if (hours <= 0) {
+    return `${minutes}分`
+  }
+
+  return `${hours}時間${minutes.toString().padStart(2, '0')}分`
+}
+
+export const formatMinutesAndSeconds = (ms: number): string => {
+  if (!ms || ms <= 0) {
+    return '0秒'
+  }
+
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+
+  if (minutes <= 0) {
+    return `${seconds}秒`
+  }
+
+  return `${minutes}分${seconds.toString().padStart(2, '0')}秒`
+}
+
+export const formatDateRange = (start: Date, end: Date): string => {
+  if (!isValid(start) || !isValid(end)) {
+    return 'データなし'
+  }
+
+  const startLabel = format(start, 'yyyy/MM/dd')
+  const endLabel = format(end, 'yyyy/MM/dd')
+
+  if (startLabel === endLabel) {
+    return startLabel
+  }
+
+  return `${startLabel} 〜 ${endLabel}`
+}
+

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -63,20 +63,9 @@
         </div>
 
         <template v-if="hasData">
-          <div class="grid gap-6 md:grid-cols-3">
-            <div class="rounded-xl border border-spotify-border bg-spotify-dark-secondary p-6 shadow-lg shadow-black/30">
-              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-spotify-text-muted">総再生回数</p>
-              <p class="mt-3 text-4xl font-semibold text-white">
-                {{ totalPlays.toLocaleString() }}
-                <span class="ml-1 text-base font-normal text-spotify-text-secondary">回</span>
-              </p>
-            </div>
+          <StatsOverview />
 
-            <div class="rounded-xl border border-spotify-border bg-spotify-dark-secondary p-6 shadow-lg shadow-black/30">
-              <p class="text-xs font-semibold uppercase tracking-[0.3em] text-spotify-text-muted">総再生時間</p>
-              <p class="mt-3 text-3xl font-semibold text-white">{{ formattedTotalPlayTime }}</p>
-            </div>
-
+          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
             <div class="rounded-xl border border-spotify-border bg-spotify-dark-secondary p-6 shadow-lg shadow-black/30">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-spotify-text-muted">ユニークアーティスト</p>
               <p class="mt-3 text-4xl font-semibold text-white">
@@ -96,7 +85,7 @@
             <ul class="mt-6 space-y-4 text-sm">
               <li
                 v-for="summary in dataSourceSummaries"
-                :key="summary.source"
+                :key="summary.sourcePath"
                 class="flex flex-wrap items-start justify-between gap-4 rounded-lg border border-spotify-border/60 bg-spotify-dark p-4 transition hover:border-spotify-green/60"
               >
                 <div>
@@ -121,30 +110,14 @@
 import { computed, onMounted } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useSpotifyData } from '@/composables/useSpotifyData'
+import StatsOverview from '@/components/dashboard/StatsOverview.vue'
 import { useDataStore } from '@/stores/dataStore'
 
 const dataStore = useDataStore()
 const { rawData, dataSources, isLoading, error } = storeToRefs(dataStore)
 const { loadHistoryData } = useSpotifyData()
 
-const formatDuration = (ms: number): string => {
-  if (!ms || ms <= 0) {
-    return '0分'
-  }
-  const totalSeconds = Math.floor(ms / 1000)
-  const hours = Math.floor(totalSeconds / 3600)
-  const minutes = Math.floor((totalSeconds % 3600) / 60)
-  if (hours === 0) {
-    return `${minutes}分`
-  }
-  return `${hours}時間${minutes.toString().padStart(2, '0')}分`
-}
-
 const totalPlays = computed(() => rawData.value.length)
-const totalPlayTimeMs = computed(() =>
-  rawData.value.reduce((acc, item) => acc + (item?.ms_played ?? 0), 0)
-)
-const formattedTotalPlayTime = computed(() => formatDuration(totalPlayTimeMs.value))
 
 const uniqueArtistCount = computed(() => {
   const set = new Set<string>()
@@ -162,6 +135,7 @@ const uniqueArtistCount = computed(() => {
 const dataSourceSummaries = computed(() =>
   dataSources.value.map((source) => ({
     source: source.source,
+    sourcePath: source.sourcePath,
     itemCount: source.items.length,
     loadedAt: source.loadedAt,
   }))


### PR DESCRIPTION
## Summary
- ダッシュボード向けに統計カード `StatsOverview` を新規追加
- 再生時間や日付範囲を整形するフォーマッターをユーティリティとして実装
- `DashboardView` に統計カードを組み込み Issue #3 の要件を満たす

## Testing
- 未実施（UI変更のみ）

close #3